### PR TITLE
Fixing analyzer warning: UNUSED_CATCH_CLAUSE

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -112,7 +112,7 @@ class Client extends http.BaseClient {
     try {
       challenges = AuthenticationChallenge.parseHeader(
           response.headers['www-authenticate']);
-    } on FormatException catch (_) {
+    } on FormatException {
       return response;
     }
 

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -95,7 +95,7 @@ class Credentials {
     var parsed;
     try {
       parsed = JSON.decode(json);
-    } on FormatException catch (_) {
+    } on FormatException {
       validate(false, 'invalid JSON');
     }
 

--- a/lib/src/handle_access_token_response.dart
+++ b/lib/src/handle_access_token_response.dart
@@ -44,7 +44,7 @@ Credentials handleAccessTokenResponse(
   var parameters;
   try {
     parameters = JSON.decode(response.body);
-  } on FormatException catch (_) {
+  } on FormatException {
     validate(false, 'invalid JSON');
   }
 
@@ -111,7 +111,7 @@ void _handleErrorResponse(http.Response response, Uri tokenEndpoint) {
   var parameters;
   try {
     parameters = JSON.decode(response.body);
-  } on FormatException catch (_) {
+  } on FormatException {
     validate(false, 'invalid JSON');
   }
 


### PR DESCRIPTION
Fixing analyzer warnings such as:

46: The exception variable 'e' is not used, so the 'catch' clause can be removed [UNUSED_CATCH_CLAUSE]
113: The exception variable 'e' is not used, so the 'catch' clause can be removed [UNUSED_CATCH_CLAUSE]
