### PR TITLE
chore: set max SDK version to <3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: dart
 dart: dev
 
 dart_task:
-  - test: --platform vm,firefox
+- test: --platform vm,firefox
 
 # Only run one instance of the formatter and the analyzer, rather than running
 # them against each Dart version.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: dart
 
-dart:
-- dev
+dart: dev
+
 dart_task:
-- test: --platform vm,firefox
+  - test: --platform vm,firefox
 
 # Only run one instance of the formatter and the analyzer, rather than running
 # them against each Dart version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 1.2.2
+
+* Set max SDK version to <3.0.0, and adjusted other dependencies.
+
 # 1.2.1
 
-* Updated SDK version to 2.0.0-dev.17.0
+* Updated SDK version to 2.0.0-dev.17.0.
 
 # 1.2.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,0 @@
-analyzer:
-  strong-mode: true

--- a/lib/src/parameters.dart
+++ b/lib/src/parameters.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 
 /// The type of a callback that parses parameters from an HTTP response.
@@ -25,10 +24,8 @@ Map<String, dynamic> parseJsonParameters(MediaType contentType, String body) {
   }
 
   var untypedParameters = jsonDecode(body);
-  if (untypedParameters is! Map) {
-    throw new FormatException(
-        'Parameters must be a map, was "$untypedParameters"');
+  if (untypedParameters is Map) {
+    return untypedParameters.cast<String, dynamic>();
   }
-
-  return DelegatingMap.typed(untypedParameters);
+  throw FormatException('Parameters must be a map, was "$untypedParameters"');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,20 @@
 name: oauth2
-version: 1.2.1
-author: Dart Team <misc@dartlang.org>
-homepage: https://github.com/dart-lang/oauth2
+version: 1.2.2
+
 description: >
   A client library for authenticating with a remote service via OAuth2 on
   behalf of a user, and making authorized HTTP requests with the user's
   OAuth2 credentials.
+author: Dart Team <misc@dartlang.org>
+homepage: https://github.com/dart-lang/oauth2
+
 environment:
-  sdk: '>=2.0.0-dev.17.0 <2.0.0'
+  sdk: '>=2.0.0-dev.17.0 <3.0.0'
+
 dependencies:
-  collection: '^1.5.0'
-  http: '>=0.11.0 <0.12.0'
+  collection: ^1.5.0
+  http: '>=0.11.0 <0.13.0'
   http_parser: '>=1.0.0 <4.0.0'
+
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: '>=0.12.0 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
   http_parser: '>=1.0.0 <4.0.0'
 
 dev_dependencies:
-  test: '>=0.12.0 <2.0.0'
+  test: '>=0.12.42 <2.0.0'

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -28,7 +28,7 @@ void main() {
           identifier: 'identifier', secret: 'secret', httpClient: httpClient);
 
       expect(client.get(requestUri),
-          throwsA(new isInstanceOf<oauth2.ExpirationException>()));
+          throwsA(new TypeMatcher<oauth2.ExpirationException>()));
     });
 
     test(
@@ -130,7 +130,7 @@ void main() {
       });
 
       expect(client.read(requestUri),
-          throwsA(new isInstanceOf<oauth2.AuthorizationException>()));
+          throwsA(new TypeMatcher<oauth2.AuthorizationException>()));
     });
 
     test('passes through a 401 response without www-authenticate', () async {

--- a/test/handle_access_token_response_test.dart
+++ b/test/handle_access_token_response_test.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 
 import 'package:oauth2/oauth2.dart' as oauth2;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -48,8 +48,9 @@ const isAuthorizationException = const _AuthorizationException();
 /// A matcher for functions that throw AuthorizationException.
 final Matcher throwsAuthorizationException = throwsA(isAuthorizationException);
 
-class _AuthorizationException extends TypeMatcher {
-  const _AuthorizationException() : super("AuthorizationException");
+class _AuthorizationException
+    extends TypeMatcher<oauth2.AuthorizationException> {
+  const _AuthorizationException() : super();
   bool matches(item, Map matchState) => item is oauth2.AuthorizationException;
 }
 
@@ -59,7 +60,7 @@ const isExpirationException = const _ExpirationException();
 /// A matcher for functions that throw ExpirationException.
 final Matcher throwsExpirationException = throwsA(isExpirationException);
 
-class _ExpirationException extends TypeMatcher {
-  const _ExpirationException() : super("ExpirationException");
+class _ExpirationException extends TypeMatcher<oauth2.ExpirationException> {
+  const _ExpirationException() : super();
   bool matches(item, Map matchState) => item is oauth2.ExpirationException;
 }


### PR DESCRIPTION
- Replaced deprecated use of `DelegatingMap.typed()` by `cast()`.
- Cleaned up analyzer issues.

cc @kwalrath @kevmoo
