### PR TITLE
Fix auth type of resulting client.

### DIFF
--- a/lib/src/resource_owner_password_grant.dart
+++ b/lib/src/resource_owner_password_grant.dart
@@ -83,6 +83,8 @@ Future<Client> resourceOwnerPasswordGrant(
       response, authorizationEndpoint, startTime, scopes, delimiter,
       getParameters: getParameters);
   return new Client(credentials,
-      identifier: identifier, secret: secret, httpClient: httpClient,
+      identifier: identifier,
+      secret: secret,
+      httpClient: httpClient,
       basicAuth: basicAuth);
 }

--- a/lib/src/resource_owner_password_grant.dart
+++ b/lib/src/resource_owner_password_grant.dart
@@ -83,5 +83,6 @@ Future<Client> resourceOwnerPasswordGrant(
       response, authorizationEndpoint, startTime, scopes, delimiter,
       getParameters: getParameters);
   return new Client(credentials,
-      identifier: identifier, secret: secret, httpClient: httpClient);
+      identifier: identifier, secret: secret, httpClient: httpClient,
+      basicAuth: basicAuth);
 }


### PR DESCRIPTION
After a password grant the resulting OAuth2 Client resets it's basicAuth parameter to true even when it was false in the method call.