### PR TITLE
Adds OnCredentialsRefreshed callback

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -68,7 +68,7 @@ class Client extends http.BaseClient {
   Credentials _credentials;
 
   /// Callback to be invoked whenever the credentials refreshed.
-  CredentialsRefreshedCallback _onCredentialsRefreshed;
+  final CredentialsRefreshedCallback _onCredentialsRefreshed;
 
   /// Whether to use HTTP Basic authentication for authorizing the client.
   final bool _basicAuth;
@@ -161,9 +161,8 @@ class Client extends http.BaseClient {
         basicAuth: _basicAuth,
         httpClient: _httpClient);
 
-    if (_onCredentialsRefreshed != null) {
+    if (_onCredentialsRefreshed != null)
       _onCredentialsRefreshed(_credentials);
-    }
 
     return this;
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -67,6 +67,9 @@ class Client extends http.BaseClient {
   Credentials get credentials => _credentials;
   Credentials _credentials;
 
+  /// Callback to be invoked whenever the credentials refreshed.
+  CredentialsRefreshedCallback _onCredentialsRefreshed;
+
   /// Whether to use HTTP Basic authentication for authorizing the client.
   final bool _basicAuth;
 
@@ -86,9 +89,11 @@ class Client extends http.BaseClient {
   Client(this._credentials,
       {this.identifier,
       this.secret,
+      CredentialsRefreshedCallback onCredentialsRefreshed,
       bool basicAuth = true,
       http.Client httpClient})
       : _basicAuth = basicAuth,
+        _onCredentialsRefreshed = onCredentialsRefreshed,
         _httpClient = httpClient == null ? new http.Client() : httpClient {
     if (identifier == null && secret != null) {
       throw new ArgumentError("secret may not be passed without identifier.");
@@ -155,6 +160,10 @@ class Client extends http.BaseClient {
         newScopes: newScopes,
         basicAuth: _basicAuth,
         httpClient: _httpClient);
+
+    if (_onCredentialsRefreshed != null) {
+      _onCredentialsRefreshed(_credentials);
+    }
 
     return this;
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,8 +11,6 @@ import 'authorization_exception.dart';
 import 'credentials.dart';
 import 'expiration_exception.dart';
 
-// TODO(nweiz): Add an onCredentialsRefreshed event once we have some event
-// infrastructure.
 /// An OAuth2 client.
 ///
 /// This acts as a drop-in replacement for an [http.Client], while sending

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -159,8 +159,7 @@ class Client extends http.BaseClient {
         basicAuth: _basicAuth,
         httpClient: _httpClient);
 
-    if (_onCredentialsRefreshed != null)
-      _onCredentialsRefreshed(_credentials);
+    if (_onCredentialsRefreshed != null) _onCredentialsRefreshed(_credentials);
 
     return this;
   }

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -13,6 +13,9 @@ import 'handle_access_token_response.dart';
 import 'parameters.dart';
 import 'utils.dart';
 
+/// Type of the callback when credentials are refreshed.
+typedef CredentialsRefreshedCallback = void Function(Credentials);
+
 /// Credentials that prove that a client is allowed to access a resource on the
 /// resource owner's behalf.
 ///

--- a/lib/src/resource_owner_password_grant.dart
+++ b/lib/src/resource_owner_password_grant.dart
@@ -10,6 +10,7 @@ import 'package:http_parser/http_parser.dart';
 import 'client.dart';
 import 'handle_access_token_response.dart';
 import 'utils.dart';
+import 'credentials.dart';
 
 /// Obtains credentials using a [resource owner password grant][].
 ///
@@ -49,6 +50,7 @@ Future<Client> resourceOwnerPasswordGrant(
     String secret,
     Iterable<String> scopes,
     bool basicAuth = true,
+    CredentialsRefreshedCallback onCredentialsRefreshed,
     http.Client httpClient,
     String delimiter,
     Map<String, dynamic> getParameters(
@@ -84,5 +86,8 @@ Future<Client> resourceOwnerPasswordGrant(
       response, authorizationEndpoint, startTime, scopes, delimiter,
       getParameters: getParameters);
   return new Client(credentials,
-      identifier: identifier, secret: secret, httpClient: httpClient);
+      identifier: identifier,
+      secret: secret,
+      httpClient: httpClient,
+      onCredentialsRefreshed: onCredentialsRefreshed);
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -78,6 +78,7 @@ void main() {
           secret: 'secret',
           httpClient: httpClient, onCredentialsRefreshed: (credentials) {
         callbackCalled = true;
+        expect(credentials.accessToken, equals('new access token'));
       });
 
       httpClient.expectRequest((request) {

--- a/test/resource_owner_password_grant_test.dart
+++ b/test/resource_owner_password_grant_test.dart
@@ -59,13 +59,13 @@ void main() {
             headers: {'content-type': 'application/json'});
       });
 
-      var callbackCalled = false;
+      var isCallbackInvoked = false;
 
       var client = await oauth2.resourceOwnerPasswordGrant(
           authEndpoint, 'username', 'userpass',
           identifier: 'client', secret: 'secret', httpClient: expectClient,
           onCredentialsRefreshed: (oauth2.Credentials credentials) {
-        callbackCalled = true;
+        isCallbackInvoked = true;
       });
 
       expectClient.expectRequest((request) {
@@ -81,7 +81,7 @@ void main() {
       });
 
       await client.read(Uri.parse("http://example.com/resource"));
-      expect(callbackCalled, equals(true));
+      expect(isCallbackInvoked, equals(true));
     });
 
     test('builds correct request when using query parameters for client',


### PR DESCRIPTION
This adds an optional `onCredentialsRefreshed` parameter to the `Client` class, so that user can choose to be notified whenever the credential is refreshed. This is useful for Flutter when the token is refreshed in the middle of the app lifecycle. Otherwise I'd have to store the token every time after a request is made.

Currently only `resourceOwnerPasswordGrant()` consumes this parameter as I am not familiar with other types of grant flow using this library.