### PR TITLE
OpenID's id_token implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.4
+
+* OpenID's id_token treated.
+
 # 1.2.3
 
 * Support the latest `package:http` release.

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -45,7 +45,8 @@ class Credentials {
   /// End-Users to be Authenticated, contains Claims, represented as a
   /// JSON Web Token (JWT).
   ///
-  /// This may be `null`, indicating that the openid scope is not implemented.
+  /// This may be `null`, indicating that the 'openid' scope was not
+  /// requested (or not supported).
   ///
   /// [spec]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
   final String idToken;

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -41,6 +41,14 @@ class Credentials {
   /// This may be `null`, indicating that the credentials can't be refreshed.
   final String refreshToken;
 
+  /// The token that is received from the authorization server to enable
+  /// End-Users to be Authenticated, contains Claims, represented as a
+  /// JSON Web Token (JWT).
+  ///
+  /// [spec]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+  /// This may be `null`, indicating that the openid scope is not implemented.
+  final String idToken;
+
   /// The URL of the authorization server endpoint that's used to refresh the
   /// credentials.
   ///
@@ -95,6 +103,7 @@ class Credentials {
   /// [standard JSON response]: https://tools.ietf.org/html/rfc6749#section-5.1
   Credentials(this.accessToken,
       {this.refreshToken,
+      this.idToken,
       this.tokenEndpoint,
       Iterable<String> scopes,
       this.expiration,
@@ -132,7 +141,7 @@ class Credentials {
         'required field "accessToken" was not a string, was '
         '${parsed["accessToken"]}');
 
-    for (var stringField in ['refreshToken', 'tokenEndpoint']) {
+    for (var stringField in ['refreshToken', 'idToken', 'tokenEndpoint']) {
       var value = parsed[stringField];
       validate(value == null || value is String,
           'field "$stringField" was not a string, was "$value"');
@@ -155,6 +164,7 @@ class Credentials {
 
     return new Credentials(parsed['accessToken'],
         refreshToken: parsed['refreshToken'],
+        idToken: parsed['idToken'],
         tokenEndpoint: tokenEndpoint,
         scopes: (scopes as List).map((scope) => scope as String),
         expiration: expiration);
@@ -167,6 +177,7 @@ class Credentials {
   String toJson() => jsonEncode({
         'accessToken': accessToken,
         'refreshToken': refreshToken,
+        'idToken': idToken,
         'tokenEndpoint':
             tokenEndpoint == null ? null : tokenEndpoint.toString(),
         'scopes': scopes,
@@ -233,6 +244,7 @@ class Credentials {
     if (credentials.refreshToken != null) return credentials;
     return new Credentials(credentials.accessToken,
         refreshToken: this.refreshToken,
+        idToken: credentials.idToken,
         tokenEndpoint: credentials.tokenEndpoint,
         scopes: credentials.scopes,
         expiration: credentials.expiration);

--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -45,8 +45,9 @@ class Credentials {
   /// End-Users to be Authenticated, contains Claims, represented as a
   /// JSON Web Token (JWT).
   ///
-  /// [spec]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
   /// This may be `null`, indicating that the openid scope is not implemented.
+  ///
+  /// [spec]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
   final String idToken;
 
   /// The URL of the authorization server endpoint that's used to refresh the

--- a/lib/src/handle_access_token_response.dart
+++ b/lib/src/handle_access_token_response.dart
@@ -72,7 +72,7 @@ Credentials handleAccessTokenResponse(http.Response response, Uri tokenEndpoint,
           'parameter "expires_in" was not an int, was "$expiresIn"');
     }
 
-    for (var name in ['refresh_token', 'scope']) {
+    for (var name in ['refresh_token', 'id_token', 'scope']) {
       var value = parameters[name];
       if (value != null && value is! String)
         throw new FormatException(
@@ -88,6 +88,7 @@ Credentials handleAccessTokenResponse(http.Response response, Uri tokenEndpoint,
 
     return new Credentials(parameters['access_token'],
         refreshToken: parameters['refresh_token'],
+        idToken: parameters['id_token'],
         tokenEndpoint: tokenEndpoint,
         scopes: scopes,
         expiration: expiration);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth2
-version: 1.2.3
+version: 1.2.4
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/oauth2
 description: >-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth2
-version: 1.2.4
+version: 1.4.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/oauth2
 description: >-

--- a/test/credentials_test.dart
+++ b/test/credentials_test.dart
@@ -270,6 +270,7 @@ void main() {
 
       var credentials = new oauth2.Credentials('access token',
           refreshToken: 'refresh token',
+          idToken: 'id token',
           tokenEndpoint: tokenEndpoint,
           scopes: ['scope1', 'scope2'],
           expiration: expiration);
@@ -277,6 +278,7 @@ void main() {
 
       expect(reloaded.accessToken, equals(credentials.accessToken));
       expect(reloaded.refreshToken, equals(credentials.refreshToken));
+      expect(reloaded.idToken, equals(credentials.idToken));
       expect(reloaded.tokenEndpoint.toString(),
           equals(credentials.tokenEndpoint.toString()));
       expect(reloaded.scopes, equals(credentials.scopes));
@@ -303,6 +305,11 @@ void main() {
 
     test("should throw a FormatException if refreshToken is not a string", () {
       expect(() => fromMap({"accessToken": "foo", "refreshToken": 12}),
+          throwsFormatException);
+    });
+
+    test("should throw a FormatException if idToken is not a string", () {
+      expect(() => fromMap({"accessToken": "foo", "idToken": 12}),
           throwsFormatException);
     });
 

--- a/test/handle_access_token_response_test.dart
+++ b/test/handle_access_token_response_test.dart
@@ -263,11 +263,11 @@ void main() {
   group('a success response with a id_token', () {
     oauth2.Credentials handleSuccess(
         {String contentType = "application/json",
-          accessToken = 'access token',
-          tokenType = 'bearer',
-          expiresIn,
-          idToken = 'decode me',
-          scope}) {
+        accessToken = 'access token',
+        tokenType = 'bearer',
+        expiresIn,
+        idToken = 'decode me',
+        scope}) {
       return handle(new http.Response(
           jsonEncode({
             'access_token': accessToken,

--- a/test/handle_access_token_response_test.dart
+++ b/test/handle_access_token_response_test.dart
@@ -260,13 +260,12 @@ void main() {
     });
   });
 
-  group('a success response with id_token', () {
+  group('a success response with a id_token', () {
     oauth2.Credentials handleSuccess(
         {String contentType = "application/json",
           accessToken = 'access token',
           tokenType = 'bearer',
           expiresIn,
-          refreshToken,
           idToken = 'decode me',
           scope}) {
       return handle(new http.Response(
@@ -274,7 +273,6 @@ void main() {
             'access_token': accessToken,
             'token_type': tokenType,
             'expires_in': expiresIn,
-            'refresh_token': refreshToken,
             'id_token': idToken,
             'scope': scope
           }),

--- a/test/handle_access_token_response_test.dart
+++ b/test/handle_access_token_response_test.dart
@@ -259,4 +259,36 @@ void main() {
       expect(credentials.scopes, equals(['scope1', 'scope2']));
     });
   });
+
+  group('a success response with id_token', () {
+    oauth2.Credentials handleSuccess(
+        {String contentType = "application/json",
+          accessToken = 'access token',
+          tokenType = 'bearer',
+          expiresIn,
+          refreshToken,
+          idToken = 'decode me',
+          scope}) {
+      return handle(new http.Response(
+          jsonEncode({
+            'access_token': accessToken,
+            'token_type': tokenType,
+            'expires_in': expiresIn,
+            'refresh_token': refreshToken,
+            'id_token': idToken,
+            'scope': scope
+          }),
+          200,
+          headers: {'content-type': contentType}));
+    }
+
+    test('with a non-string id token throws a FormatException', () {
+      expect(() => handleSuccess(idToken: 12), throwsFormatException);
+    });
+
+    test('with a id token sets the id token', () {
+      var credentials = handleSuccess(idToken: "decode me");
+      expect(credentials.idToken, equals("decode me"));
+    });
+  });
 }


### PR DESCRIPTION
This manage the OpenID id_token response, including it on the access token and credentials.

At this moment, the library doesn't provide a way to decode the id_token that has a JWT format. You should implement it in your application level.

Closes [#8](https://github.com/dart-lang/tools/issues/304)