### PR TITLE
Prepare release of 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0
+
+* Added support for `clientCredentialsGrant`.
+
 # 1.4.0
 
 * OpenID's id_token treated.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth2
-version: 1.4.0
+version: 1.5.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/oauth2
 description: >-


### PR DESCRIPTION
Preparing release of 1.5.0 following https://github.com/dart-lang/oauth2/pull/45 (credits @thosakwe).