### PR TITLE
Add support for custom grant types

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,49 @@ var result = await client.read('http://example.com/protected-resources.txt');
 File('~/.myapp/credentials.json').writeAsString(client.credentials.toJson());
 ```
 
+## Custom Grant Type
+
+```dart
+// This URL is an endpoint that's provided by the authorization server. It's
+// usually included in the server's documentation of its OAuth2 API.
+final authorizationEndpoint =
+    Uri.parse('http://example.com/oauth2/authorization');
+
+// The grant type provided by the authorization server.
+// It's usually included in the server's documentation of its OAuth2 API.
+final grantType = {
+  'grant_type': 'installed_client',
+  'device_id': 'device_id'
+};
+
+// The authorization server may issue each client a separate client
+// identifier and secret, which allows the server to tell which client
+// is accessing it. Some servers may also have an anonymous
+// identifier/secret pair that any client may use.
+//
+// Some servers don't require the client to authenticate itself, in which case
+// these should be omitted.
+final identifier = 'my client identifier';
+final secret = 'my client secret';
+
+// Calling the top-level `customGrant` function will return a
+// [Client] instead.
+var client = await oauth2.customGrant(authorizationEndpoint, grantType,
+      identifier: identifier, secret: secret);
+
+// With an authenticated client, you can make requests, and the `Bearer` token
+// returned by the server during the client credentials grant will be attached
+// to any request you make.
+var response =
+    await client.read('https://example.com/api/some_resource.json');
+
+// You can save the client's credentials, which consists of an access token, and
+// potentially a refresh token and expiry date, to a file. This way, subsequent runs
+// do not need to reauthenticate, and you can avoid saving the client identifier and
+// secret.
+await credentialsFile.writeAsString(client.credentials.toJson());
+```
+
 [authorizationCodeGrantDocs]: https://oauth.net/2/grant-types/authorization-code/
 [authorizationCodeGrantMethod]: https://pub.dev/documentation/oauth2/latest/oauth2/AuthorizationCodeGrant-class.html
 [authorizationCodeGrantSection]: #authorization-code-grant

--- a/lib/oauth2.dart
+++ b/lib/oauth2.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/authorization_code_grant.dart';
+export 'src/custom_grant.dart';
 export 'src/client_credentials_grant.dart';
 export 'src/resource_owner_password_grant.dart';
 export 'src/client.dart';

--- a/lib/src/client_credentials_grant.dart
+++ b/lib/src/client_credentials_grant.dart
@@ -8,8 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 
 import 'client.dart';
-import 'handle_access_token_response.dart';
-import 'utils.dart';
+import 'custom_grant.dart';
 
 /// Obtains credentials using a [client credentials grant](https://tools.ietf.org/html/rfc6749#section-1.3.4).
 ///
@@ -47,33 +46,14 @@ Future<Client> clientCredentialsGrant(
     String? delimiter,
     Map<String, dynamic> Function(MediaType? contentType, String body)?
         getParameters}) async {
-  delimiter ??= ' ';
-  var startTime = DateTime.now();
+  final grantType = {'grant_type': 'client_credentials'};
 
-  var body = {'grant_type': 'client_credentials'};
-
-  var headers = <String, String>{};
-
-  if (identifier != null) {
-    if (basicAuth) {
-      headers['Authorization'] = basicAuthHeader(identifier, secret!);
-    } else {
-      body['client_id'] = identifier;
-      if (secret != null) body['client_secret'] = secret;
-    }
-  }
-
-  if (scopes != null && scopes.isNotEmpty) {
-    body['scope'] = scopes.join(delimiter);
-  }
-
-  httpClient ??= http.Client();
-  var response = await httpClient.post(authorizationEndpoint,
-      headers: headers, body: body);
-
-  var credentials = handleAccessTokenResponse(response, authorizationEndpoint,
-      startTime, scopes?.toList() ?? [], delimiter,
+  return await customGrant(authorizationEndpoint, grantType,
+      identifier: identifier,
+      secret: secret,
+      scopes: scopes,
+      basicAuth: basicAuth,
+      httpClient: httpClient,
+      delimiter: delimiter,
       getParameters: getParameters);
-  return Client(credentials,
-      identifier: identifier, secret: secret, httpClient: httpClient);
 }

--- a/lib/src/custom_grant.dart
+++ b/lib/src/custom_grant.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
+
+import 'client.dart';
+import 'credentials.dart';
+import 'handle_access_token_response.dart';
+import 'utils.dart';
+
+/// Create a custom grant type.
+///
+/// The grant type should be specified via [grantType]. This is specific to the
+/// authorization server and may be found in its documentation.
+///
+/// The client [identifier] and [secret] may be issued by the server, and are
+/// used to identify and authenticate your specific OAuth2 client. These are
+/// usually global to the program using this library.
+///
+/// The specific permissions being requested from the authorization server may
+/// be specified via [scopes]. The scope strings are specific to the
+/// authorization server and may be found in its documentation. Note that you
+/// may not be granted access to every scope you request; you may check the
+/// [Credentials.scopes] field of [Client.credentials] to see which scopes you
+/// were granted.
+///
+/// The scope strings will be separated by the provided [delimiter]. This
+/// defaults to `" "`, the OAuth2 standard, but some APIs (such as Facebook's)
+/// use non-standard delimiters.
+///
+/// By default, this follows the OAuth2 spec and requires the server's responses
+/// to be in JSON format. However, some servers return non-standard response
+/// formats, which can be parsed using the [getParameters] function.
+///
+/// This function is passed the `Content-Type` header of the response as well as
+/// its body as a UTF-8-decoded string. It should return a map in the same
+/// format as the [standard JSON response](https://tools.ietf.org/html/rfc6749#section-5.1)
+Future<Client> customGrant(
+    Uri authorizationEndpoint, Map<String, String> grantType,
+    {String? identifier,
+    String? secret,
+    Iterable<String>? scopes,
+    bool basicAuth = true,
+    CredentialsRefreshedCallback? onCredentialsRefreshed,
+    http.Client? httpClient,
+    String? delimiter,
+    Map<String, dynamic> Function(MediaType? contentType, String body)?
+        getParameters}) async {
+  delimiter ??= ' ';
+  var startTime = DateTime.now();
+
+  var body = grantType;
+
+  var headers = <String, String>{};
+
+  if (identifier != null) {
+    if (basicAuth) {
+      headers['Authorization'] = basicAuthHeader(identifier, secret!);
+    } else {
+      body['client_id'] = identifier;
+      if (secret != null) body['client_secret'] = secret;
+    }
+  }
+
+  if (scopes != null && scopes.isNotEmpty) {
+    body['scope'] = scopes.join(delimiter);
+  }
+
+  httpClient ??= http.Client();
+  var response = await httpClient.post(authorizationEndpoint,
+      headers: headers, body: body);
+
+  var credentials = handleAccessTokenResponse(response, authorizationEndpoint,
+      startTime, scopes?.toList() ?? [], delimiter,
+      getParameters: getParameters);
+  return Client(credentials,
+      identifier: identifier,
+      secret: secret,
+      httpClient: httpClient,
+      onCredentialsRefreshed: onCredentialsRefreshed);
+}


### PR DESCRIPTION
This is an initial support for custom grant types. The implementation is identical to the `resourceOwnerPasswordGrant` while also refactoring it and `clientCredentialsGrant` to use the new implementation.