### PR TITLE
Optionally remove secret from get token request

### DIFF
--- a/lib/src/authorization_code_grant.dart
+++ b/lib/src/authorization_code_grant.dart
@@ -218,6 +218,10 @@ class AuthorizationCodeGrant {
   /// passed to a server controlled by the client as query parameters on the
   /// redirect URL.
   ///
+  /// Use the *includeSecret* parameter if you would like to control whether the
+  /// client secret is to be contained in the post request for obtaining a
+  /// token.
+  ///
   /// It is a [StateError] to call this more than once, to call it before
   /// [getAuthorizationUrl] is called, or to call it after
   /// [handleAuthorizationCode] is called.
@@ -229,8 +233,8 @@ class AuthorizationCodeGrant {
   /// value.
   ///
   /// Throws [AuthorizationException] if the authorization fails.
-  Future<Client> handleAuthorizationResponse(
-      Map<String, String> parameters) async {
+  Future<Client> handleAuthorizationResponse(Map<String, String> parameters,
+      {bool includeSecret = true}) async {
     if (_state == _State.initial) {
       throw StateError('The authorization URL has not yet been generated.');
     } else if (_state == _State.finished) {
@@ -261,7 +265,8 @@ class AuthorizationCodeGrant {
           '"code".');
     }
 
-    return _handleAuthorizationCode(parameters['code']);
+    return _handleAuthorizationCode(parameters['code'],
+        includeSecret: includeSecret);
   }
 
   /// Processes an authorization code directly.
@@ -292,7 +297,8 @@ class AuthorizationCodeGrant {
 
   /// This works just like [handleAuthorizationCode], except it doesn't validate
   /// the state beforehand.
-  Future<Client> _handleAuthorizationCode(String? authorizationCode) async {
+  Future<Client> _handleAuthorizationCode(String? authorizationCode,
+      {bool includeSecret = true}) async {
     var startTime = DateTime.now();
 
     var headers = <String, String>{};
@@ -304,7 +310,7 @@ class AuthorizationCodeGrant {
       'code_verifier': _codeVerifier
     };
 
-    var secret = this.secret;
+    var secret = includeSecret ? this.secret : null;
     if (_basicAuth && secret != null) {
       headers['Authorization'] = basicAuthHeader(identifier, secret);
     } else {


### PR DESCRIPTION
Microsoft identity platform's authentication flow for native & single page apps requires that the post request to get an access token has no client secret in it (See the **client_secret** description in the table of [this section in the documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-access-token-with-a-client_secret)).

For this reason, I have implemented an optional parameter for AuthorizationCodeGrant.handleAuthorizationResponse (and in turn, the _handleAuthorizationCode method aswell) to control whether the client secret should be included in this post request.

---

- [✓] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
