### PR TITLE
add refresh_expires_in property to credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build/
 packages
 .packages
+*idea
 
 # Or the files created by dart2js.
 *.dart.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 build/
 packages
 .packages
-*idea
+.idea/
 
 # Or the files created by dart2js.
 *.dart.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 build/
 packages
 .packages
-.idea/
 
 # Or the files created by dart2js.
 *.dart.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.3-wip
 
 * Require `package:http` v1.0.0
+* add property `refreshToKenExpiration` to `Credentials`
 
 ## 2.0.2
 

--- a/test/handle_access_token_response_test.dart
+++ b/test/handle_access_token_response_test.dart
@@ -118,6 +118,7 @@ void main() {
         Object? accessToken = 'access token',
         Object? tokenType = 'bearer',
         Object? expiresIn,
+        Object? refreshExpiresIn,
         Object? refreshToken,
         Object? scope}) {
       return handle(http.Response(
@@ -125,6 +126,7 @@ void main() {
             'access_token': accessToken,
             'token_type': tokenType,
             'expires_in': expiresIn,
+            'refresh_expires_in': refreshExpiresIn,
             'refresh_token': refreshToken,
             'scope': scope
           }),
@@ -228,9 +230,23 @@ void main() {
           startTime.millisecondsSinceEpoch + 90 * 1000);
     });
 
+    test(
+        'with refresh-expires-in sets the expiration to ten seconds earlier than'
+        ' the server says', () {
+      var credentials = handleSuccess(refreshExpiresIn: 100);
+      expect(credentials.refreshToKenExpiration?.millisecondsSinceEpoch,
+          startTime.millisecondsSinceEpoch + 90 * 1000);
+    });
+
     test('with expires-in encoded as string', () {
       var credentials = handleSuccess(expiresIn: '110');
       expect(credentials.expiration?.millisecondsSinceEpoch,
+          startTime.millisecondsSinceEpoch + 100 * 1000);
+    });
+
+    test('with expires-in encoded as string', () {
+      var credentials = handleSuccess(refreshExpiresIn: '110');
+      expect(credentials.refreshToKenExpiration?.millisecondsSinceEpoch,
           startTime.millisecondsSinceEpoch + 100 * 1000);
     });
 
@@ -275,6 +291,7 @@ void main() {
         Object? accessToken = 'access token',
         Object? tokenType = 'bearer',
         Object? expiresIn,
+        Object? refreshExpiresIn,
         Object? idToken = 'decode me',
         Object? scope}) {
       return handle(http.Response(
@@ -282,6 +299,7 @@ void main() {
             'access_token': accessToken,
             'token_type': tokenType,
             'expires_in': expiresIn,
+            'refresh_expires_in': refreshExpiresIn,
             'id_token': idToken,
             'scope': scope
           }),


### PR DESCRIPTION
- Added the property `refresh_expires_in` property. This can help e.g. when the access token and refresh token is expired. With this property it is easier to handle the expiration of the refresh token. 
When the access token is expired and the lib tries to get a new access token with an expired refresh token, this will probably lead to and error.

---

- [✓] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
