### PR TITLE
Proposed Solution for #114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.3-wip
 
 * Require `package:http` v1.0.0
+* Added optional `enablePKCE` parameter to `AuthorizationCodeGrant` constructor.
 
 ## 2.0.2
 

--- a/lib/src/authorization_code_grant.dart
+++ b/lib/src/authorization_code_grant.dart
@@ -131,14 +131,14 @@ class AuthorizationCodeGrant {
   /// whenever the credentials are refreshed.
   ///
   /// If [enablePKCE] is `true` (the default), the authorization code flow will
-  /// use PKCE as defined in 
+  /// use PKCE as defined in
   /// [RFC 7636](https://tools.ietf.org/html/rfc7636#section-4). Otherwise, the
-  /// [Authorization Request] will not include the added `code_challenge` and 
-  /// `code_challenge_method` parameters, and the [Access Token Request] will 
+  /// [Authorization Request] will not include the added `code_challenge` and
+  /// `code_challenge_method` parameters, and the [Access Token Request] will
   /// not include the added `code_verifier` parameter. This is not recommended,
-  /// and should only be used if the server doesn't support the 
+  /// and should only be used if the server doesn't support the
   /// [RFC 7636](https://tools.ietf.org/html/rfc7636#section-4) extension.
-  /// 
+  ///
   /// [Access Token Request]: https://tools.ietf.org/html/rfc7636#section-4.5
   /// [Authorization Request]: https://tools.ietf.org/html/rfc7636#section-4.3
   ///


### PR DESCRIPTION
This PR makes the usage of PKCE optional via an optional named constructor parameter in `AuthorizationCodeGrant` (`enablePKCE`). 

This change was in response to an API which fails when using PKCE, like described in dart-lang/tools#360. I've tested this code by modifying my installed package files directly with this change.

The default behavior is for `enablePKCE` to be `true`, which results in no change in behavior. When this is `false`, this removes the PKCE-related parameters in the authorization code flow.

This shouldn't break anything; the new parameter is optional and sets a private final field that only affects `getAuthorizationUrl` and `_handleAuthorizationCode`, one of which is private, both of which operate identically when the parameter is not changed, thus any theoretical derived classes would not break.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
